### PR TITLE
fixed bg and image for auth pages

### DIFF
--- a/app/helpers/statuses_helper.rb
+++ b/app/helpers/statuses_helper.rb
@@ -35,7 +35,7 @@ module StatusesHelper
   end
 
   def svg_logo_dd
-    tag(:img, { :src => "../btj_styles/logoBTJ.png", :class => "smallLogo", :width => '300px', :height => '100px' }, false)
+    tag(:img, { :src => "../btj_styles/logoBTJ.png", :class => "largeLogo" }, false)
   end
 
   def svg_logo_full_dd

--- a/app/views/layouts/auth.html.haml
+++ b/app/views/layouts/auth.html.haml
@@ -1,6 +1,6 @@
 - content_for :header_tags do
   = javascript_pack_tag 'public', integrity: true, crossorigin: 'anonymous'
-  %link{:href => "/assets/btj_styles/style.css", :rel => "stylesheet"}/
+  %link{:href => "/btj_styles/style.css", :rel => "stylesheet"}/
 
 - content_for :content do
   .container-alt


### PR DESCRIPTION
Css import was pointing to assets/btj_styles folder. This folder only exists locally. Fixed the link to point to public/btj_styles/style.css, and the background and images should be correctly styled.